### PR TITLE
allow to define prefixes of watched producers

### DIFF
--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -229,10 +229,18 @@ function isProducerWatched(cfg, nextMessage, producer) {
     return false;
   }
 
-  return cfg.subscribe &&
-    cfg.subscribe.producers &&
-    cfg.subscribe.producers.length > 0 &&
-    cfg.subscribe.producers.includes(producer);
+  if(!cfg.subscribe ||
+     !cfg.subscribe.producers ||
+     cfg.subscribe.producers.length == 0) {
+    return false;
+  }
+
+  cfg.subscribe.producers.forEach((watchedProducer) => {
+    if(producer.startsWith(watchedProducer)) {
+      return true;
+    }
+  });
+  return false;
 }
 function isValidatorWatched(cfg, voter) {
   return cfg.subscribe &&


### PR DESCRIPTION
Instead of matching whole strings of producers with these changes we can just define a common prefix for all of them.