### PR TITLE
Update for substrate-telemetry rust backend

### DIFF
--- a/src/lib/client.js
+++ b/src/lib/client.js
@@ -9,7 +9,7 @@ const { timeToFinality,
         newBlockProduced,
       } = require('./prometheus');
 
-const address = 'ws://localhost:8080';
+const address = 'ws://localhost:8000/feed';
 const socket = new WebSocket(address);
 const Actions = {
   FeedVersion      : 0,


### PR DESCRIPTION
The rust backend for substrate-telemetry now is served on port 8000 by default and requires the /feed route for accessing the data feed.