### PR TITLE
Fixes CLI option parsing & adds '--telemetry-host' option

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,6 @@ async function start(options={}) {
 
   const cfg = readYAML(options.config);
   const client = new Client(cfg);
-
   await client.start();
 }
 
@@ -30,4 +29,5 @@ function  readYAML(filePath) {
   return yaml.safeLoad(rawContent);
 }
 
+program.parse(process.argv);
 start(program);


### PR DESCRIPTION
This fixes CLI argument parsing & adds a new option `--telemetry-host` to allows an instance of the exporter to connect to an arbitrary host